### PR TITLE
ADD: background image mixin retina option

### DIFF
--- a/sass/system/_mixins.scss
+++ b/sass/system/_mixins.scss
@@ -1,14 +1,22 @@
-// @include background-image(logo, png, 100px, 100px, center, no-repeat);
-@mixin background-image($file, $type, $width, $height, $position, $repeat) {
+// @include background-image(logo, png, 100px, 100px, center, no-repeat, true);
+@mixin background-image($file, $type, $width, $height, $position, $repeat, $retina: null) {
 
-	background-image: url($image-path + $file + '.' + $type);
-	background-position: $position;
-	background-repeat: $repeat;
+    background-image: url($image-path + $file + '.' + $type);
+    background-position: $position;
+    background-repeat: $repeat;
+    background-size: $width $height;
 
-	@include hidpi(1.3) {
-        background-image: url($image-path + $file + '-2x.' + $type);
-        background-size: $width $height;
-	}
+    @if $retina == true {
+
+        @include hidpi(1.3) { // @2x
+            background-image: url($image-path + $file + '@2x.' + $type);
+        }
+
+        @include hidpi(2.25) { // @3x
+            background-image: url($image-path + $file + '@3x.' + $type);
+        }
+
+    }
 
 }
 


### PR DESCRIPTION
New option inside backgound-image mixin "retina". It has a fallback of null if you don't want/have retina image
